### PR TITLE
Added: AvatarFirstTimeEventMessage

### DIFF
--- a/src/common/packet/game/AvatarFirstTimeEventMessage.h
+++ b/src/common/packet/game/AvatarFirstTimeEventMessage.h
@@ -11,23 +11,23 @@
     When the first time events (FTE's) are received, battle experience is awarded.
     Text information about the object will be displayed.
     A certain itemized checkbox under the 'Training' tab that corresponds is marked off.
-    This indicates which tracked items have not yet been "encountered."
+    The latter list indicates all "encounterable" game objects for which a FTE exists.
     These effects only happen once per character/campaign.
     (The Motion Sensor will occasionally erronously display the information window on repeat encounters.
     No additional experience, though.)
 
     First time events (FTE's) are recorded in a great list in the middle of player ObjectCreateMessage data.
     Tutorial complete events are enqueued nearby.
-    @property player_uid the player
+    @property avatar_uid the player
     @property object_id the game object that triggers the event
     @property unk na
     @property event_name the string name of the event
 */
 class AvatarFirstTimeEventMessage {
 public:
-    uint32_t unk;
     uint16_t avatar_uid;
     uint16_t object_id;
+    uint32_t unk;
     std::string event_name;
 
     static AvatarFirstTimeEventMessage decode(BitStream &bitstream) {

--- a/src/common/packet/game/AvatarFirstTimeEventMessage.h
+++ b/src/common/packet/game/AvatarFirstTimeEventMessage.h
@@ -1,0 +1,41 @@
+#pragma once
+
+#include "common/packet/opcodes.h"
+#include "common/bitstream.h"
+
+/**
+    Dispatched to the server when the player encounters something for the very first time in their campaign.
+    For example, the first time the player rubs up against a game object with a yellow exclamation point.
+    For example, the first time the player draws a specific weapon.
+
+    When the first time events (FTE's) are received, battle experience is awarded.
+    Text information about the object will be displayed.
+    A certain itemized checkbox under the 'Training' tab that corresponds is marked off.
+    This indicates which tracked items have not yet been "encountered."
+    These effects only happen once per character/campaign.
+    (The Motion Sensor will occasionally erronously display the information window on repeat encounters.
+    No additional experience, though.)
+
+    First time events (FTE's) are recorded in a great list in the middle of player ObjectCreateMessage data.
+    Tutorial complete events are enqueued nearby.
+    @property player_uid the player
+    @property object_id the game object that triggers the event
+    @property unk na
+    @property event_name the string name of the event
+*/
+class AvatarFirstTimeEventMessage {
+public:
+    uint32_t unk;
+    uint16_t avatar_uid;
+    uint16_t object_id;
+    std::string event_name;
+
+    static AvatarFirstTimeEventMessage decode(BitStream &bitstream) {
+        AvatarFirstTimeEventMessage packet;
+        bitstream.read(packet.avatar_uid);
+        bitstream.read(packet.object_id);
+        bitstream.read(packet.unk);
+        bitstream.read(packet.event_name);
+        return packet;
+    }
+};

--- a/src/common/packet/pkt_all.h
+++ b/src/common/packet/pkt_all.h
@@ -12,6 +12,7 @@
 #include "crypto/ClientFinished.h"
 #include "crypto/ServerChallengeXchg.h"
 #include "crypto/ServerFinished.h"
+#include "game/AvatarFirstTimeEventMessage.h"
 #include "game/CharacterInfoMessage.h"
 #include "game/CharacterRequestMessage.h"
 #include "game/ConnectToWorldMessage.h"

--- a/src/common/packet/pkt_test_game.cpp
+++ b/src/common/packet/pkt_test_game.cpp
@@ -163,6 +163,20 @@ void testSetCurrentAvatarMessage() {
     assertBuffersEqual(testEncodingBuf, encodedBuf);
 }
 
+void testAvatarFirstTimeEventMessage() {
+    static std::vector<uint8_t> decodeBuf = hexToBytes(
+        "69 4b00 c000 01000000 9e 766973697465645f63657274696669636174696f6e5f7465726d696e616c");
+
+    //decode
+    BitStream decodeBitStream(decodeBuf);
+    assertOpcode(decodeBitStream, OP_AvatarFirstTimeEventMessage);
+    AvatarFirstTimeEventMessage decodePacket = AvatarFirstTimeEventMessage::decode(decodeBitStream);
+    assertEqual(decodePacket.avatar_uid, 75);
+    assertEqual(decodePacket.object_id, 192);
+    assertEqual(decodePacket.unk, 1);
+    assertEqual(decodePacket.event_name, "visited_certification_terminal");
+}
+
 void testPacketCodingGame() {
     testCharacterInfoMessage();
     testCharacterRequestMessage();
@@ -175,4 +189,5 @@ void testPacketCodingGame() {
     // TODO: Test ObjectCreateMessage
     testSetCurrentAvatarMessage();
     // TODO: Test VNLWorldStatusMessage
+	testAvatarFirstTimeEventMessage();
 }

--- a/src/common/packet/pkt_test_game.cpp
+++ b/src/common/packet/pkt_test_game.cpp
@@ -189,5 +189,5 @@ void testPacketCodingGame() {
     // TODO: Test ObjectCreateMessage
     testSetCurrentAvatarMessage();
     // TODO: Test VNLWorldStatusMessage
-	testAvatarFirstTimeEventMessage();
+    testAvatarFirstTimeEventMessage();
 }

--- a/src/common/util.cpp
+++ b/src/common/util.cpp
@@ -49,7 +49,7 @@ int hexCharToInt(char c) {
     } else if (c >= 'A' && c <= 'F') {
         return 10 + c - 'A';
     } else if (c >= 'a' && c <= 'f') {
-        return 10 + c - 'A';
+        return 10 + c - 'a';
     }
 
     return -1;


### PR DESCRIPTION
The packet is mostly straightforward.  I may need to go back and reformat the comments so that some doc tool accepts them in the future.  Unless the Scala packet file already is commented, and I would be porting that over with specific corrections, however, I'll be writing new comments.

Also worth noting is the change to hexCharToInt.  The test for the packet is a demonstration of the change in action.